### PR TITLE
Add video tutorial to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Most companies nowadays are paying customers of one of the many cloud vendors in
 In order to be able to make intelligent decisions about costs and resources, it is necessary to understand not only the current state of the resources, but also what will be the possible evolution of them. The customer should be capable of understanding the future evolution of the resources and costs if no action is taken, or if some action is taken on the source.
 
 In this project,we aim to manage Cloud Costs by using Machine Learning algorithms such as Classification and Linear Regression. Besides choosing the right cloud service and service provider, we aim to **forecast** the upcoming costs and hence be prepared for any overhead and cut on extra costs if things go out of hand. Finally, we aim to optimize cloud usage by finding adjacencies in cloud services to choose the best provider.
+
+Below is a video overview of the Project Statement and Exploratory Data Analysis in the JupyterHub environment.
+
+`video: https://www.youtube.com/watch?v=jne4auRnxJ4&feature=youtu.be`


### PR DESCRIPTION
## Related Issues and Dependencies

Add video tutorial to the README such that the [page](https://www.operate-first.cloud/data-science/cloud-price-analysis/) on the operate first site contains a preview to the YouTube video.

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

https://github.com/operate-first/operate-first.github.io/issues/162

## Description

Adds video in required format to markdown. 
https://github.com/operate-first/operate-first.github.io/blob/master/content/examples/markdown.md#add-videos